### PR TITLE
#14 use new activity results api

### DIFF
--- a/javasample/build.gradle
+++ b/javasample/build.gradle
@@ -20,6 +20,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -30,5 +39,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.fragment:fragment:1.3.2'
 
 }

--- a/javasample/src/main/java/com/example/javasampe/MainActivity.java
+++ b/javasample/src/main/java/com/example/javasampe/MainActivity.java
@@ -1,16 +1,24 @@
 package com.example.javasampe;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.ActivityNotFoundException;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
+import com.example.javasampe.databinding.ActivityMainBinding;
 import com.globalaccelerex.globalaccelerexandroidposclientlibrary.GAClientLib;
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.contracts.PosContracts;
 import com.globalaccelerex.globalaccelerexandroidposclientlibrary.printing.TextAlignment;
 import com.globalaccelerex.globalaccelerexandroidposclientlibrary.printing.Receipt;
 import com.globalaccelerex.globalaccelerexandroidposclientlibrary.printing.ReceiptFormat;
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.transactions.Transaction;
 import com.globalaccelerex.globalaccelerexandroidposclientlibrary.util.Countries;
+
+import java.util.Objects;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -18,21 +26,31 @@ public class MainActivity extends AppCompatActivity {
             .setCountryCode(Countries.NIGERIA)
             .build();
 
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-        Button printReceipt = findViewById(R.id.print_receipt);
+        ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
 
+        ActivityResultLauncher<Transaction> transaction = registerForActivityResult(new PosContracts.CardTransactionContract(), result -> {
+            String transactionStatus = result.getRequestStatus() == null ? "Cancelled/Failed" : result.getRequestStatus().toString();
+            Toast.makeText(MainActivity.this, "Response: " + transactionStatus, Toast.LENGTH_LONG).show();
+        });
 
-        printReceipt.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ReceiptFormat format = new ReceiptFormat(MainActivity.this);
-                format.addSingleLine("This is a java test line", TextAlignment.ALIGN_LEFT, null , false);
-                format.addSingleLine("Just to confirm!!", TextAlignment.ALIGN_CENTER, null, false);
-                Receipt receipt = format.generatePaymentReceipt();
-                clientLib.getPrinter().printReceipt(receipt, MainActivity.this);
+        binding.printReceipt.setOnClickListener(v -> {
+            ReceiptFormat format = new ReceiptFormat(MainActivity.this);
+            format.addSingleLine("This is a java test line", TextAlignment.ALIGN_LEFT, null, false);
+            format.addSingleLine("Just to confirm!!", TextAlignment.ALIGN_CENTER, null, false);
+            Receipt receipt = format.generatePaymentReceipt();
+            clientLib.getPrinter().printReceipt(receipt, MainActivity.this);
+        });
+
+        binding.transactionRequest.setOnClickListener(view -> {
+            try {
+                transaction.launch(Transaction.purchase(1.0, true));
+            } catch (ActivityNotFoundException e) {
+                Toast.makeText(this, "Payment app not installed", Toast.LENGTH_SHORT).show();
             }
         });
 

--- a/pos-client-library/build.gradle
+++ b/pos-client-library/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    implementation "androidx.activity:activity-ktx:1.2.2"
+    implementation 'androidx.fragment:fragment-ktx:1.3.2'
 }
 
 

--- a/pos-client-library/build.gradle
+++ b/pos-client-library/build.gradle
@@ -32,6 +32,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+        freeCompilerArgs += '-Xexplicit-api=warning'
+    }
 }
 
 tasks.withType(Javadoc) {

--- a/pos-client-library/build.gradle
+++ b/pos-client-library/build.gradle
@@ -7,14 +7,14 @@ apply plugin: 'maven-publish'
 
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
     lintOptions {
         abortOnError false
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 7
         versionName libraryVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -45,12 +45,13 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'com.squareup.retrofit2:converter-gson:2.6.2'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation "androidx.activity:activity-ktx:1.2.2"
 }
 
 

--- a/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/contracts/PosContracts.kt
+++ b/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/contracts/PosContracts.kt
@@ -1,0 +1,43 @@
+package com.globalaccelerex.globalaccelerexandroidposclientlibrary.contracts
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.baseAppUtils.BaseAppConstants
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.baseAppUtils.CardTransaction
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.baseAppUtils.CardTransactionResponse
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.transactions.Transaction
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.util.ParsingUtil
+import com.globalaccelerex.globalaccelerexandroidposclientlibrary.util.RequestStatus
+import com.google.gson.Gson
+
+/**
+ * Activity Results Contracts for all possible POS APIs
+ */
+public object PosContracts {
+
+    public class CardTransactionContract :
+        ActivityResultContract<Transaction, CardTransactionResponse>() {
+        override fun createIntent(context: Context, input: Transaction): Intent {
+            return Intent(BaseAppConstants.TRANSACTION_REQUEST_INTENT_ADDRESS)
+                .putExtra(BaseAppConstants.REQUEST_DATA_TAG, input.request())
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): CardTransactionResponse {
+            if (resultCode != Activity.RESULT_OK)
+                return CardTransactionResponse(RequestStatus.CANCELLED, null)
+            return try {
+                val status = intent?.getStringExtra("status")
+                val jsonData = intent?.getStringExtra("data")
+                val cardTransaction = Gson().fromJson(jsonData, CardTransaction::class.java)
+                CardTransactionResponse(
+                    requestStatus = ParsingUtil.getStatus(status),
+                    transactionData = cardTransaction
+                )
+            } catch (e: Exception) {
+                CardTransactionResponse(RequestStatus.CANCELLED, null)
+            }
+        }
+    }
+}

--- a/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/Transaction.kt
+++ b/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/Transaction.kt
@@ -1,0 +1,74 @@
+package com.globalaccelerex.globalaccelerexandroidposclientlibrary.transactions
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+
+/**
+ * Creates a transaction request
+ * @param amount amount of transaction
+ * @param printReceipt if you want to print your own custom receipt, set this to false
+ */
+public sealed class Transaction(
+    public open val amount: Double,
+    public open val printReceipt: Boolean
+) {
+    protected val gson: Gson by lazy {
+        GsonBuilder()
+            .create()
+    }
+
+    public abstract fun request(): String
+
+    /**
+     * Creates a purchase transaction request.
+     */
+    internal data class Purchase(override val amount: Double, override val printReceipt: Boolean) :
+        Transaction(amount, printReceipt) {
+        override fun request(): String {
+            val transactionRequest = TransactionRequest(
+                amount = amount.toString(),
+                printReceipt = printReceipt.toString(),
+                transType = TransactionType.PURCHASE.name
+            )
+            return gson.toJson(transactionRequest)
+        }
+    }
+
+    /**
+     * Purchase with cashback transaction
+     * @param cashbackAmount the cashback amount
+     * @param amount the amount of transaction (does not include the cashback amount)
+     */
+    internal data class PurchaseWithCb(
+        override val amount: Double,
+        val cashbackAmount: Double,
+        override val printReceipt: Boolean
+    ) : Transaction(amount, printReceipt) {
+        override fun request(): String {
+            val transactionRequest = TransactionRequest(
+                amount = amount.toString(),
+                printReceipt = printReceipt.toString(),
+                transType = TransactionType.PURCHASEWITHCB.name
+            )
+            return gson.toJson(transactionRequest)
+        }
+    }
+
+
+    public companion object {
+
+        /**
+         * Creates a purchase transaction request.
+         */
+        @JvmStatic
+        public fun purchase(amount: Double, printReceipt: Boolean): Transaction =
+            Purchase(amount, printReceipt)
+
+        @JvmStatic
+        public fun purchaseWithCb(
+            amount: Double,
+            cashbackAmount: Double,
+            printReceipt: Boolean
+        ): Transaction = PurchaseWithCb(amount, cashbackAmount, printReceipt)
+    }
+}

--- a/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/TransactionRequest.kt
+++ b/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/TransactionRequest.kt
@@ -1,0 +1,25 @@
+package com.globalaccelerex.globalaccelerexandroidposclientlibrary.transactions
+
+import com.google.gson.annotations.SerializedName
+
+internal data class TransactionRequest(
+    @SerializedName("amount")
+    val amount: String,
+    @SerializedName("cashBackAmount")
+    val cashBackAmount: String? = null,
+    @SerializedName("transType")
+    val transType: String,
+    @SerializedName("print")
+    val printReceipt: String,
+    /**
+     * Custom reference
+     */
+    @SerializedName("transactionReference")
+    val reference: String? = null,
+
+    /**
+     * For things like reversals, sale completion
+     */
+    @SerializedName("rrn")
+    val rrn: String? = null
+)

--- a/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/TransactionType.kt
+++ b/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/transactions/TransactionType.kt
@@ -1,0 +1,8 @@
+package com.globalaccelerex.globalaccelerexandroidposclientlibrary.transactions
+
+internal enum class TransactionType {
+
+    PURCHASE,
+    PURCHASEWITHCB,
+    REFUND
+}

--- a/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/util/ConstantParameters.kt
+++ b/pos-client-library/src/main/java/com/globalaccelerex/globalaccelerexandroidposclientlibrary/util/ConstantParameters.kt
@@ -1,18 +1,16 @@
 package com.globalaccelerex.globalaccelerexandroidposclientlibrary.util
 
-import kotlinx.android.parcel.Parcelize
-
-enum class Countries{
+public enum class Countries {
     NIGERIA, KENYA, GHANA
 }
 
-enum class MobileMoneyOperators{
+public enum class MobileMoneyOperators {
     MTN, TIGO, VODAFONE
 }
 
-sealed class RequestStatus {
-    object SUCCESS: RequestStatus()
-    object FAILED: RequestStatus()
-    object CANCELLED: RequestStatus()
-    object TIMEOUT: RequestStatus()
+public enum class RequestStatus {
+    SUCCESS,
+    FAILED,
+    CANCELLED,
+    TIMEOUT
 }


### PR DESCRIPTION
I attempted to use the new activity results API. Currently, only handled Purchase and Purchase with Cashback. We can proceed to add other transaction types if it looks good to everyone